### PR TITLE
chore(deps): upgrade go to v1.23

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.18', '1.19', '1.20']
+        go: ['1.22', '1.23']
     name: Go ${{ matrix.go }} test
     steps:
       - uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/zitadel/schema
 
-go 1.18
+go 1.22


### PR DESCRIPTION
Add Go 1.23 to the build matrix and readme.

Related to https://github.com/zitadel/zitadel/issues/8906